### PR TITLE
Fix typo in extension.md

### DIFF
--- a/docs/docs/reference/extend/translation.md
+++ b/docs/docs/reference/extend/translation.md
@@ -66,7 +66,7 @@ implicit class SeqOps[T](private val $this: List[T]) extends AnyVal {
 
 Now, assume an extension
 
-    extension if <type-params> <implicit-params> for <type> : <parents> { <body> }
+    extension <id> <type-params> <implicit-params> for <type> : <parents> { <body> }
 
 where `<type-params>`, `<implicit-params>` and `<type>` are as before.
 This extension is translated to


### PR DESCRIPTION
I think `extension if` is supposed to be `extension <id>` there