### PR TITLE
Fix an issue that when we print tasty the name buffer gets written twice

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -78,7 +78,7 @@ class Pickler extends Phase {
       // println(i"rawBytes = \n$rawBytes%\n%") // DEBUG
       if (pickling ne noPrinter) {
         println(i"**** pickled info of $cls")
-        println(new TastyPrinter(pickler.assembleParts()).printContents())
+        println(new TastyPrinter(pickled).printContents())
       }
     }
   }


### PR DESCRIPTION
This is an issue when we run diagnostic to print Tasty tree and doubles the name buffer, which is misleading when debugging.

