### PR TITLE
Add +1 to zinc positions in the compiler bridge

### DIFF
--- a/sbt-bridge/src/xsbt/DelegatingReporter.java
+++ b/sbt-bridge/src/xsbt/DelegatingReporter.java
@@ -88,7 +88,7 @@ final public class DelegatingReporter extends AbstractReporter {
           else return Optional.ofNullable(src.file().path());
         }
         public Optional<Integer> line() {
-          int line = pos.line();
+          int line = pos.line() + 1;
           if (line == -1) return Optional.empty();
           else return Optional.of(line);
         }

--- a/sbt-dotty/sbt-test/compilerReporter/simple/project/Reporter.scala
+++ b/sbt-dotty/sbt-test/compilerReporter/simple/project/Reporter.scala
@@ -29,6 +29,12 @@ object Reporter {
       println(problems.toList)
       assert(problems.size == 1)
 
+      // make sure position reported by zinc are proper
+      val mainProblem = problems.head
+      val line = mainProblem.position().line() 
+      assert(line.isPresent() == true)
+      assert(line.get() == 9)
+      
       // Assert disabled because we don't currently pass positions to sbt
       // See https://github.com/lampepfl/dotty/pull/2107
       // assert(problems.forall(_.position.offset.isDefined))


### PR DESCRIPTION
In the previous version of the compiler bridge we were adding 1 here:

https://github.com/sbt/zinc/blob/fc58a39402ca7abfda17133a5b3a43de3344ca49/internal/compiler-bridge/src/main/scala/xsbt/DelegatingReporter.scala#L99

which means Zinc expects line numbers starting at 1, while in Dotty we provided it with ones starting at 0.
This wasn't an issue when using `dotc` and sbt, since `dotc` added 1 to show the correct line number and sbt most likely used the Dotty rendered message due to:
https://github.com/sbt/zinc/pull/699/files?diff=unified&w=1

This poped up when adding some test in Bloop: https://github.com/tgodzik/bloop/pull/1