### PR TITLE
Use foreach instead of manual iterator loops in Seq.deleted/updatedWith/splitAround

### DIFF
--- a/library/src/scala/collection/Seq.scala
+++ b/library/src/scala/collection/Seq.scala
@@ -986,11 +986,10 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   def deleted(index: Int): C^{this} = {
     if (index < 0) throw new IndexOutOfBoundsException(index.toString)
     val b = newSpecificBuilder
-    val it = iterator
+    b.sizeHint(this, -1)
     var i = 0
     var found = false
-    while (it.hasNext) {
-      val a = it.next()
+    foreach { a =>
       if (i == index) found = true else b += a
       i += 1
     }
@@ -1015,17 +1014,13 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   def updatedWith[B >: A](index: Int, f: A => Option[B]): CC[B]^{this} = {
     if (index < 0) throw new IndexOutOfBoundsException(index.toString)
     val b = iterableFactory.newBuilder[B]
-    val it = iterator
+    b.sizeHint(this)
     var i = 0
     var found = false
-    while (it.hasNext) {
-      val a = it.next()
+    foreach { a =>
       if (i == index) {
         found = true
-        f(a) match {
-          case Some(replacement) => b += replacement
-          case None =>
-        }
+        f(a).foreach(b += _)
       } else b += a
       i += 1
     }
@@ -1049,13 +1044,12 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   def splitAround[A1 >: A](separator: A1): (C^{this}, C^{this}) = {
     val before = newSpecificBuilder
     val after = newSpecificBuilder
-    val it = iterator
-    var found = false
-    while (!found && it.hasNext) {
-      val a = it.next()
-      if (a == separator) found = true else before += a
+    var switched = false
+    foreach { a =>
+      if (switched) after += a
+      else if (a == separator) switched = true
+      else before += a
     }
-    while (it.hasNext) after += it.next()
     (before.result(), after.result())
   }
 


### PR DESCRIPTION
deleted, updatedWith, and splitAround each traversed their receiver
via `val it = iterator; while (it.hasNext) { ... it.next() ... }`,
even though none of them rely on iterator-specific capabilities —
every element is visited unconditionally in all three (splitAround's
two-loop shape looks like it needs a resumable iterator, but the same
logic is expressible as a single pass with a boolean flag).

Switch all three to foreach, which dispatches to each collection's
own native traversal (e.g. List walking cons cells directly,
index-based loops for array-backed types) instead of allocating an
Iterator and paying two virtual calls (hasNext/next) per element.

Additional changes:

- deleted: add b.sizeHint(this, -1). The result size is always known
  exactly once a valid index is found (source size minus one), so the
  builder can avoid backing-array resizes as elements are added.
- updatedWith: add b.sizeHint(this), optimistically sized for the
  common case where f returns Some (result size == source size).
  sizeHint is documented to tolerate being wrong, so a None at the
  matched index only costs a harmless one-element overshoot. Also
  replaced the manual `f(a) match { case Some(v) => b += v; case
  None => }` with `f(a).foreach(b += _)`, matching Option.foreach
  usage elsewhere in this file.
- splitAround: rewritten as a single pass driven by a `switched`
  boolean instead of two sequential iterator loops. No sizeHint added
  here, since the split position is data-dependent and there's no
  reliable size estimate available for either builder in advance.

No behavior changes; existing tests should cover this as-is.
