### PR TITLE
Use foreach instead of manual iterator loops in fullIntersection

### DIFF
--- a/library/src/scala/collection/Set.scala
+++ b/library/src/scala/collection/Set.scala
@@ -227,14 +227,10 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
     val onlyThis = newSpecificBuilder
     val both = newSpecificBuilder
     val onlyThat = iterableFactory.newBuilder[B]
-    val it = iterator
-    while (it.hasNext) {
-      val a = it.next()
+    foreach { a =>
       if (that.contains(a)) both += a else onlyThis += a
     }
-    val it2 = that.iterator
-    while (it2.hasNext) {
-      val b = it2.next()
+    that.foreach { b =>
       // the cast is erasure-safe: `contains` only uses equality, like `that.diff(this)` would
       if (!this.contains(b.asInstanceOf[A])) onlyThat += b
     }


### PR DESCRIPTION
fullIntersection traversed both `this` and `that` via
`val it = iterator; while (it.hasNext) { ... it.next() ... }`, even
though neither loop relies on iterator-specific behavior — each is a
single unconditional pass over its collection, and the two loops
don't interleave or share iterator state.

Switch both to foreach, so each collection dispatches to its own
native traversal (e.g. List walking cons cells directly, index-based
loops for array-backed types) instead of allocating an Iterator and
paying two virtual calls (hasNext/next) per element. Same change
already applied to deleted/updatedWith/splitAround.

No sizeHint added to any of the three builders (onlyThis, both,
onlyThat): the split between onlyThis and both depends entirely on
how much of `this` overlaps with `that`, and onlyThat's size depends
symmetrically on how much of `that` overlaps with `this` — neither is
knowable in advance, so a size hint would risk over-allocating
whichever builder turns out small rather than helping.

The method remains O(|this| + |that|) with two O(1)-average contains
checks (one per loop) — the theoretical floor for a 3-way set
partition, since deriving onlyThat requires a full pass over `that`
independent of what the first loop over `this` already determined.

No behavior changes.