### PR TITLE
Use foreachEntry and avoid repeated Map.updated in invert

### DIFF
--- a/library/src/scala/collection/Map.scala
+++ b/library/src/scala/collection/Map.scala
@@ -423,14 +423,10 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
    */
   def invert[V1 >: V]: immutable.Map[V1, immutable.Set[K]] = {
     val m = mutable.Map.empty[V1, mutable.Builder[K, immutable.Set[K]]]
-    val it = iterator
-    while (it.hasNext) {
-      val kv = it.next()
-      m.getOrElseUpdate(kv._2, immutable.Set.newBuilder[K]) += kv._1
-    }
-    var result = immutable.Map.empty[V1, immutable.Set[K]]
-    m.foreachEntry((v, bldr) => result = result.updated(v, bldr.result()))
-    result
+    foreachEntry((k, v) => m.getOrElseUpdate(v, immutable.Set.newBuilder[K]) += k)
+    val b = immutable.Map.newBuilder[V1, immutable.Set[K]]
+    m.foreachEntry((v, bldr) => b += ((v, bldr.result())))
+    b.result()
   }
 
   override def addString(sb: StringBuilder, start: String, sep: String, end: String): sb.type =


### PR DESCRIPTION
invert had two separate inefficiencies:

1. The first loop traversed `this` via a manual
   `val it = iterator; while (it.hasNext) { val kv = it.next(); ... }`,
   destructuring kv._1/kv._2 by hand. Switched to foreachEntry, which
   for Map/HashMap-backed types walks the internal table directly and
   invokes the callback with key and value as separate arguments,
   avoiding the tuple allocation/unpacking the manual iterator version
   paid for on every entry.

2. The second loop rebuilt the result via
   `result = result.updated(v, bldr.result())` inside m.foreachEntry.
   Each .updated call on an immutable.Map reallocates trie nodes along
   the path to the changed key and discards the previous map version
   as garbage — the same anti-pattern already fixed in groupFlatMap.
   Replaced it with a single immutable.Map.newBuilder, populated via
   the same foreachEntry pass and materialized once via b.result().

No sizeHint added to either builder: the number of distinct inverted
keys, and how source entries distribute across them, is
data-dependent and unknowable before the first pass completes — a
hint sized against `this` would risk over-allocating whenever many
keys invert to the same value, which is a common case for this method.

No behavior changes.