### PR TITLE
Use foreach and sizeHint in mapAccumulate

### DIFF
--- a/library/src/scala/collection/Iterable.scala
+++ b/library/src/scala/collection/Iterable.scala
@@ -792,10 +792,10 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    */
   def mapAccumulate[B, S](z: S)(f: (A, S) => (B, S)): (CC[B], S) = {
     val b = iterableFactory.newBuilder[B]
+    b.sizeHint(this)
     var state = z
-    val it = iterator
-    while (it.hasNext) {
-      val (mapped, next) = f(it.next(), state)
+    foreach { a =>
+      val (mapped, next) = f(a, state)
       b += mapped
       state = next
     }


### PR DESCRIPTION
mapAccumulate traversed via a manual
`val it = iterator; while (it.hasNext) { ... it.next() ... }` loop,
even though nothing about the method needs iterator-specific
capability — no early exit, and every element is visited
unconditionally.

Switch to foreach, which dispatches to each collection's own native
traversal (e.g. List walking cons cells directly, index-based loops
for array-backed types) instead of allocating an Iterator and paying
two virtual calls (hasNext/next) per element.

This is safe for mapAccumulate specifically because the state (S) is
threaded sequentially through calls to f in traversal order, and
foreach/iterator are guaranteed to visit a given collection's
elements in the same order as each other — so the switch doesn't
change which elements state gets threaded through in which order.

Also add b.sizeHint(this): mapAccumulate always produces exactly one
B per input element, so unlike some other methods in this file where
a sizeHint would only be a guess, here the result size is known
exactly in advance and the builder can size itself accordingly.

No behavior changes.