### PR TITLE
Fuse mapWithIndex into a single lazy view, avoiding tuple allocation

### DIFF
--- a/library/src/scala/collection/Iterable.scala
+++ b/library/src/scala/collection/Iterable.scala
@@ -788,8 +788,23 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    *  @return   a new $coll containing `f(a, i)` for each element `a` at index `i`
    *            of this $coll, in encounter order
    */
-  def mapWithIndex[B](f: (A, Int) => B): CC[B]^{this, f} =
-    iterableFactory.from(new View.Map(new View.ZipWithIndex(this), (pair: (A, Int)) => f(pair._1, pair._2)))
+  def mapWithIndex[B](f: (A, Int) => B): CC[B]^{this, f} = {
+    val self = this
+    iterableFactory.from(new AbstractView[B] {
+      def iterator: Iterator[B]^{self, f} = new AbstractIterator[B] {
+        private[this] val it = self.iterator
+        private[this] var i = 0
+        def hasNext = it.hasNext
+        def next(): B = {
+          val res = f(it.next(), i)
+          i += 1
+          res
+        }
+      }
+      override def knownSize: Int = self.knownSize
+      override def isEmpty: Boolean = self.isEmpty
+    })
+  }
 
   /** Returns a $coll formed from this $coll and another iterable collection
    *  by combining corresponding elements in pairs.


### PR DESCRIPTION
mapWithIndex composed two existing view combinators:

  new View.Map(new View.ZipWithIndex(this), (pair: (A, Int)) => f(pair._1, pair._2))

ZipWithIndex's iterator constructs a real (A, Int) tuple per element;
View.Map's function then immediately destructures that tuple and
discards it. This also means two View instances and, once traversed,
two chained Iterator instances wrap `this`, where one fused instance
would do.

This PR replaces that with a single anonymous AbstractView[B] that
threads the index as a mutable field on its own iterator rather than
pairing it with each element.

`self` is captured explicitly, since an unqualified `this` inside the
anonymous AbstractView body refers to the view itself rather than the
enclosing collection. The inner iterator method is annotated
Iterator[B]^{self, f} so the capture checker accepts that it holds
onto self and f, mirroring the outer method's own CC[B]^{this, f}
annotation.

Laziness is preserved: nothing in `this` is evaluated until the
resulting view is traversed, matching existing tests asserting zero
element evaluations immediately after calling mapWithIndex.

No behavior changes: same result values, same traversal order, same
laziness guarantees as before.